### PR TITLE
Fix small typo

### DIFF
--- a/docs/en/GettingStarted/build-stores-with-vtex-io/3-SettingYourStoreTheme.md
+++ b/docs/en/GettingStarted/build-stores-with-vtex-io/3-SettingYourStoreTheme.md
@@ -6,7 +6,7 @@ The **Store Theme** is a default theme applicable to all VTEX IO stores. The the
 
 - **Declares styles**, configuring primary and secondary colors, typography scales and spacing, etc.
 
-This means that the Store Theme is a default theme responsible for defining the basic look of your store's font.
+This means that the Store Theme is a default theme responsible for defining the basic look of your store's front.
 
 VTEX IO Toolbelt offers the `vtex init` command which can quickly copy Store Theme to your computer where it may be configured and customized according to your business needs.
 


### PR DESCRIPTION
Fix "store's font" typo, it should be "store's front".

<img width="1014" alt="store-font" src="https://user-images.githubusercontent.com/19555647/64347616-9adc8f00-cfca-11e9-8d96-5b6e0db7cc18.png">
