### PR TITLE
Fix markdown for image links and other small fixes

### DIFF
--- a/docs/en/GettingStarted/build-stores-with-vtex-io/3-SettingYourStoreTheme.md
+++ b/docs/en/GettingStarted/build-stores-with-vtex-io/3-SettingYourStoreTheme.md
@@ -48,7 +48,7 @@ $ cd store-theme
  $ vtex link
 ```
 
-[VTEX link example](https://user-images.githubusercontent.com/52087100/61887229-9dca6700-aed7-11e9-9934-030a153b75b6.png)
+![VTEX link example](https://user-images.githubusercontent.com/52087100/61887229-9dca6700-aed7-11e9-9934-030a153b75b6.png)
 
 When linking Store Theme, your computer's local files are synced with the VTEX IO platform. This means that any change done locally to the code will be sent to and reflected in your workspace.
 
@@ -56,7 +56,7 @@ When linking Store Theme, your computer's local files are synced with the VTEX I
 
 To better understand the default theme's structure, let's have a closer look at the files that were created in your local files. You can browse through your code with whatever editor you prefer.
 
-[Repository tree](https://user-images.githubusercontent.com/52087100/61887339-ce120580-aed7-11e9-8c7b-eb55d12def2b.png)
+![Repository tree](https://user-images.githubusercontent.com/52087100/61887339-ce120580-aed7-11e9-8c7b-eb55d12def2b.png)
 
 - **manifest.json**: main file of any app. It saves important metadata, such as _vendor_, name, version, app dependencies and builders.
 
@@ -72,6 +72,6 @@ Navigate again to your new store by accessing:
 
 After the login, you should already see Store Theme reflected in your store:
 
-[Store Theme](https://user-images.githubusercontent.com/52087100/61896668-d4aa7800-aeeb-11e9-906b-9d6b04fd03c0.png)
+![Store Theme](https://user-images.githubusercontent.com/52087100/61896668-d4aa7800-aeeb-11e9-906b-9d6b04fd03c0.png)
 
 Now that your store is online and has a default theme, we can build its identity by configuring its templates and customizing its styles.

--- a/docs/en/GettingStarted/build-stores-with-vtex-io/3-SettingYourStoreTheme.md
+++ b/docs/en/GettingStarted/build-stores-with-vtex-io/3-SettingYourStoreTheme.md
@@ -30,7 +30,7 @@ You'll receive important information about Store Theme, such as vendor, name, ti
 Replace the predefined vendor value with the account name of the store that you are developing, so that you'll be able to correctly publish its theme later on. 
 </div>
 
-[toolbelt-store-theme-selection](https://user-images.githubusercontent.com/52087100/61887063-3d3b2a00-aed7-11e9-92b8-653c4972a218.png)
+![toolbelt-store-theme-selection](https://user-images.githubusercontent.com/52087100/61887063-3d3b2a00-aed7-11e9-92b8-653c4972a218.png)
 
 ## Linking your local code to VTEX IO
 

--- a/docs/en/GettingStarted/build-stores-with-vtex-io/4-ConfiguringTemplates.md
+++ b/docs/en/GettingStarted/build-stores-with-vtex-io/4-ConfiguringTemplates.md
@@ -56,9 +56,9 @@ You may customize already declared Store Theme blocks as well as new ones freely
 
 ## Declaring a new block
 
-Let’s now add a new [__infocard__](https://vtex.io/docs/components/all/vtex.store-components/info-card) component to your store’s homepage, before the shelf. To do this, we’ll need to add `info-cardf#bestdeals` to the `store.home` template in `home.jsonc`. Then, we will declare the block below in the same file.
+Let’s now add a new [__infocard__](https://vtex.io/docs/components/all/vtex.store-components/info-card) component to your store’s homepage, before the shelf. To do this, we’ll need to add `info-card#bestdeals` to the `store.home` template in `home.jsonc`. Then, we will declare the block below in the same file.
 
-[newblock-step4](https://user-images.githubusercontent.com/52087100/61960418-ca47b700-af9b-11e9-8787-b68cafae1225.png)
+![newblock-step4](https://user-images.githubusercontent.com/52087100/61960418-ca47b700-af9b-11e9-8787-b68cafae1225.png)
 
 ```
 "info-card#bestdeals": {
@@ -77,10 +77,10 @@ Let’s now add a new [__infocard__](https://vtex.io/docs/components/all/vtex.st
 ```
 
 <div class="alert alert-info">
-Your store’s component behavior varies according to each block’s defined properties. Check out the block configuration examples for each component in our <a href="">related documentation</a>.
+Your store’s component behavior varies according to each block’s defined properties. Check out the block configuration examples for each component in our <a href="https://vtex.io/docs/components/all">related documentation</a>.
 </div>
 
-When saving your changes in code and running `vtex.link` in your terminal, you should see the rendered new Infocard in your store’s homepage:  
+When saving your changes in code and running `vtex link` in your terminal, you should see the rendered new Infocard in your store’s homepage:  
 
 ![BANNER-INFOCARD-STEP4-FORREAL](https://user-images.githubusercontent.com/52087100/61972032-e73db380-afb6-11e9-833e-977964fe5105.png)
 


### PR DESCRIPTION
I've added a "!" before the image links, so they can be rendered as images.

I also made some small fixes in the configuring templates file.