### PR TITLE
Upgrades messages overwriting api doc to V2

### DIFF
--- a/docs/en/Recipes/store/overwriting-the-messages-app.md
+++ b/docs/en/Recipes/store/overwriting-the-messages-app.md
@@ -29,8 +29,8 @@ This recipe will show you how to overwrite the Messages app and easily create ne
 4. Write the following mutation command in the text box that is displayed:
 
 ```
-mutation Save($save: SaveArgs!){
-  save(args: $save)
+mutation Save($args: SaveArgsV2!) {
+  saveV2(args: $args)
 }
 ```
 
@@ -39,25 +39,27 @@ mutation Save($save: SaveArgs!){
 
 ```
 {
-  "save": {
+  "args": {
     "to": "en-US",
-    "messagesByProvider": [{
-      "provider": "vtex.login@2.x",
-      "messages": [{
-        "id": "store/login.signIn",
-        "content": "Welcome! Please log in "
-      }]
-    }]
+    "messages": [
+      {
+        "srcLang": "en-DV",
+        "srcMessage": "store/login.signIn",
+        "targetMessage": "Welcome! Please log in ",
+        "context": "vtex.login@2.x"
+      }
+    ]
   }
 }
 ```
 
-Note that the variable values `to`, `provider`, `id` and `content` will tell the Messages app where and what the message change will be. Therefore, **these variables are flexible and must fit your store's desired scenario**. The variables are as follows:
+Note that the variable values `to`, `srcLang`, `srcMessage`, `targetMessage` and `context` will tell the Messages app where and what the message change will be. Therefore, **these variables are flexible and must fit your store's desired scenario**. The variables are as follows:
 
-- `to`: where the message is located. 
-- `provider`: App message provider. 
-- `id`: message ID.
-- `content`: message content itself. 
+- `to`: Target translation locale. 
+- `srcLang`: Original message locale. 
+- `srcMessage`: Original message string.
+- `targetMessage`: The message translation.
+- `context`: The context of the message translation.
 
 Following the given example above, your admin should look similar to this: 
 
@@ -72,7 +74,7 @@ The expected response is as follows:
 ```
 {
   "data": {
-    "save": true
+    "saveV2": true
   }
 }
 ```

--- a/docs/en/Recipes/store/overwriting-the-messages-app.md
+++ b/docs/en/Recipes/store/overwriting-the-messages-app.md
@@ -56,18 +56,17 @@ mutation Save($args: SaveArgsV2!) {
 Note that the variable values `to`, `srcLang`, `srcMessage`, `targetMessage` and `context` will tell the Messages app where and what the message change will be. Therefore, **these variables are flexible and must fit your store's desired scenario**. The variables are as follows:
 
 - `to`: Target translation locale. 
-- `srcLang`: Original message locale. 
+- `srcLang`: Original message locale.
 - `srcMessage`: Original message string.
 - `targetMessage`: The message translation.
 - `context`: The context of the message translation.
 
 Following the given example above, your admin should look similar to this: 
 
-![overriding-messages-interface](https://user-images.githubusercontent.com/52087100/66517040-bdc1fd80-eab8-11e9-8082-ab0c4bdc640e.png)
 
-Finally, click on the play button to run the declared mutation. 
+![overriding-messages-interface](https://user-images.githubusercontent.com/284515/68409148-5bb2f180-0165-11ea-94c2-b2f34c8c9f44.png)
 
-![overwriting-messages-play](https://user-images.githubusercontent.com/52087100/66517074-d29e9100-eab8-11e9-9d30-2fd4e91d4de1.png)
+Finally, click on the play button to run the declared mutation.
 
 The expected response is as follows:
 


### PR DESCRIPTION
There were some changes to the messages API lately, but no change was made to the doc. This caused some problems with people coming to me asking "How do I use Messages API V2"

Since the old API has already been deprecated, I think it's ok to change this doc accordingly. 