### PR TITLE
Add missing languages to code blocks

### DIFF
--- a/docs/en/GettingStarted/build-stores-with-vtex-io/2-BasicSetupToDevelopInVTEXIO.md
+++ b/docs/en/GettingStarted/build-stores-with-vtex-io/2-BasicSetupToDevelopInVTEXIO.md
@@ -8,7 +8,7 @@ To install VTEX IO’s CLI, you need to ensure that [Node.js](https://nodejs.org
 
 Thereafter, type `yarn global add vtex` in your computer’s terminal.
 
-```
+```sh
 $ yarn global add vtex
 ```
 
@@ -20,7 +20,7 @@ $ yarn global add vtex
 
 Once VTEX IO’s CLI is installed, you can login to your VTEX account with the following command. This would in turn open a browser window asking for your credentials.
 
-```
+```sh
 $ vtex login {account}
 ```
 
@@ -34,7 +34,7 @@ When you are logged in, you can use the `vtex whoami` command to uncover which *
 
 When using VTEX IO, any interaction with an account happens in a **workspace**. As you log into a store, you are automatically in its master workspace, meaning you are in the version available to the end user. Therefore, always remember to create a development workspace using the `vtex use` command whenever you want to test a new configuration. 
 
-```
+```sh
 $ vtex use {examplename}
 ```
 

--- a/docs/en/GettingStarted/build-stores-with-vtex-io/3-SettingYourStoreTheme.md
+++ b/docs/en/GettingStarted/build-stores-with-vtex-io/3-SettingYourStoreTheme.md
@@ -18,13 +18,13 @@ The following apps need to be <a href="https://vtex.io/docs/recipes/store/instal
 
 Using your terminal, navigate to an already existing local files directory where you want Store Theme to be copied to. Then, use the `vtex init` command, select the `store-theme` option and confirm that you want to download the theme folder to the destination you just chose.
 
-```
+```sh
 $ cd {examplefolder}
 ```
 
 Notice that `{examplefolder}` should be replaced with the folder name where the Store Theme is going to be copied to.
 
-```
+```sh
 $ vtex init
 ```
 
@@ -44,11 +44,11 @@ Now that Store Theme has been copied to your local folder, you have to run `cd s
 Run <code>vtex whoami</code> to be sure that you're in the right account and in a development workspace. Otherwise, Toolbelt will not accept the link directly with the master workspace.
 </div>
 
-```
+```sh
 $ cd store-theme
 ```
 
-```
+```sh
  $ vtex link
 ```
 

--- a/docs/en/GettingStarted/build-stores-with-vtex-io/4-ConfiguringTemplates.md
+++ b/docs/en/GettingStarted/build-stores-with-vtex-io/4-ConfiguringTemplates.md
@@ -13,7 +13,7 @@ As we have previously seen, the folder responsible for organizing your store’s
 For a better understanding of this structure, let’s have a look at your store’s predefined homepage Store Theme template using the code editor of your choice. Access `store` > `blocks`> `home`> `home.jsonc` and you will be able to check out the following example:
 
 
-```
+```json
 {
  "store.home": {
    "blocks": [
@@ -25,10 +25,11 @@ For a better understanding of this structure, let’s have a look at your store�
      "rich-text#link"
      "newsletter"
    ]
- }, 
-    (...)
+ },
+  (...)
 }
 ```
+
 As we can see, the default `store.home` homepage template declares the following blocks: 
 
 - `carousel#home`
@@ -43,7 +44,7 @@ This means that your default store homepage components will be comprised of thes
 
 You’ll be able to find each block’s declaration in this same file, as in the following example:
 
-```
+```json
 "rich-text#question": {
   "props": {
     "text": "**This is an example store built using the VTEX platform.\nWant to know more?**",
@@ -60,7 +61,7 @@ Let’s now add a new [__infocard__](https://vtex.io/docs/components/all/vtex.st
 
 ![newblock-step4](https://user-images.githubusercontent.com/52087100/61960418-ca47b700-af9b-11e9-8787-b68cafae1225.png)
 
-```
+```json
 "info-card#bestdeals": {
    "props": {
      "isFullModeStyle": false,
@@ -72,8 +73,6 @@ Let’s now add a new [__infocard__](https://vtex.io/docs/components/all/vtex.st
      "textAlignment": "center"
    }
  },
-
-
 ```
 
 <div class="alert alert-info">

--- a/docs/en/GettingStarted/build-stores-with-vtex-io/5-CustomizingStyles.md
+++ b/docs/en/GettingStarted/build-stores-with-vtex-io/5-CustomizingStyles.md
@@ -2,34 +2,31 @@
 
 The `style.json` file in the `style` folder is the one responsible for defining your theme’s style. This means that you can customize your entire store’s appearance by simply adjusting the default definitions declared in this file, without the need to declare CSS for each page’s components.
 
-
 Thankfully, this is easy to do thanks to the [VTEX Styleguide](https://styleguide.vtex.com/#/Styles), a highly-configurable CSS framework responsible for defining the component style guideline. There, your can find a proper translation for what your `styles.json` file props and blocks mean in order to help your customization. 
-
 
 For example: in `style.json`, we can set the default theme background color to blue, by simply changing the `semanticColors` block’s `base` property:
 
-```
+```json
 "semanticColors": {
-        "background": {
-          "base": "#00BFFF",
-          "base--inverted": "#03044e",
-          "action-primary": "#0F3E99",
-          "action-secondary": "#eef3f7",
-          "emphasis": "#f71963",
-          "disabled": "#f2f4f5",
-          "success": "#8bc34a",
-          "success--faded": "#eafce3",
-          "danger": "#ff4c4c",
-          "danger--faded": "#ffe6e6",
-          "warning": "#ffb100",
-          "warning--faded": "#fff6e0",
-          "muted-1": "#727273",
-          "muted-2": "#979899",
-          "muted-3": "#cacbcc",
-          "muted-4": "#e3e4e6",
-          "muted-5": "#f2f4f5"
-        },
-        
+  "background": {
+    "base": "#00BFFF",
+    "base--inverted": "#03044e",
+    "action-primary": "#0F3E99",
+    "action-secondary": "#eef3f7",
+    "emphasis": "#f71963",
+    "disabled": "#f2f4f5",
+    "success": "#8bc34a",
+    "success--faded": "#eafce3",
+    "danger": "#ff4c4c",
+    "danger--faded": "#ffe6e6",
+    "warning": "#ffb100",
+    "warning--faded": "#fff6e0",
+    "muted-1": "#727273",
+    "muted-2": "#979899",
+    "muted-3": "#cacbcc",
+    "muted-4": "#e3e4e6",
+    "muted-5": "#f2f4f5"
+  },
 ```
 
 Save the changes made to your code and check out your store’s new appearance:
@@ -52,12 +49,10 @@ Classes should be individually customized within the file. You can find a compon
 
 In the `vtex.store-components.css` file, declare the following CSS replacement:
 
-```
+```css
 .infoCardContainer {
- background-color: #E71111
-
+  background-color: #E71111
 }
-
 ```
 
 Save your changes and access your store once more to check out the Infocards new red style having overwritten your store’s predefined blue:
@@ -78,20 +73,19 @@ For example: let’s customize the way in which the `info-card#bestdeals` block 
 
 ![INFOCARD-BLOCKCLASS-FORREAL-REAL](https://user-images.githubusercontent.com/52087100/61976127-54564680-afc1-11e9-9f62-ab3473639805.png)
 
-```
+```json
 "info-card#bestdeals": {
-    "props": {
-      "blockClass": "sales",
-      "isFullModeStyle": false,
-      "textPosition": "center",
-      "imageUrl": "http://cybercitycomix.com/wp-content/uploads/2015/08/Sale-sign.jpg",
-      "headline": "BEST DEALS",
-      "callToActionText": "DISCOVER",
-      "callToActionUrl": "/sale/d",
-      "textAlignment": "center"
-    }
-  },
-
+  "props": {
+    "blockClass": "sales",
+    "isFullModeStyle": false,
+    "textPosition": "center",
+    "imageUrl": "http://cybercitycomix.com/wp-content/uploads/2015/08/Sale-sign.jpg",
+    "headline": "BEST DEALS",
+    "callToActionText": "DISCOVER",
+    "callToActionUrl": "/sale/d",
+    "textAlignment": "center"
+  }
+},
 ```
 
 <div class="alert alert-info">
@@ -100,11 +94,10 @@ The <code>blockClass</code> property can have a value of your choosing, as long 
 
 To correctly reference the block, simply add the `blockClass` property value in one of your component’s CSS replacement adhering to the `.{class}--{blockClassvalue}` format.
 
-```
+```css
 .infoCardContainer--sales {
   background-color: #E6BB12
 }
-
 ```
 
 After saving the changes, you can see the Infocard with its exclusive customization:

--- a/docs/en/Recipes/layout/configuring-custom-images-for-the-sku-selector.md
+++ b/docs/en/Recipes/layout/configuring-custom-images-for-the-sku-selector.md
@@ -9,7 +9,7 @@ git: "https://github.com/vtex-apps/io-documentation/blob/master/docs/en/Recipes/
 
 # Configuring custom images for the SKU Selector
 
-## Introduction 
+## Introduction
 
 By default, the [SKU selector](https://vtex.io/docs/app/vtex.store-components/sku-selector) component uses **miniatures of SKU images** when rendered.
 
@@ -34,7 +34,7 @@ Follow the step-by-step below to see how to apply this configuration in your sto
 4. Upload the file in the `File` field and set an ID for the recently uploaded file in the `Label` field. Click on **Save** after performing all your changes.
 5. In your theme's code `sku-selector` block, add the `thumbnailImage` prop, whose past value should be the same as the label added in the catalog. For example:
 
-```
+```json
 "sku-selector":{  
   "props": {  
     "thumbnailImage": ["LabelName"]  
@@ -50,7 +50,7 @@ The way out of this scenario is to **hide the custom image** that's linked to th
 
 6. In the `product-images` block you can use the `hiddenImages` prop to activate a sort of image blacklist. This prop's value should be the custom image's label, the same one used in the previous step. For example: 
 
-```
+```json
 "product-images": {  
   "props": {  
     "displayThumbnailsArrows": true,  

--- a/docs/en/Recipes/layout/creating-a-new-custom-page.md
+++ b/docs/en/Recipes/layout/creating-a-new-custom-page.md
@@ -57,7 +57,7 @@ Let's suppose we are going to create a simple About Us page for a store. As such
 
 To do so, in your store theme's code, declare a new template within your `blocks` folder or `blocks.jsonc` file
 
-```
+```json
 {
  "store.custom#{templatename}": {
      "blocks": [  
@@ -68,7 +68,7 @@ To do so, in your store theme's code, declare a new template within your `blocks
 
 Then, fill it out with the blocks that will set the desired layout:
 
-```
+```json
 {
  "store.custom#{templatename}": {
    "blocks": [
@@ -121,27 +121,25 @@ Now that your page layout has been defined in the store theme code, the next ste
 
 In your theme's source code, access the `routes.json` file. It can be found in the `store` folder. There, add a path to the recently created template's JSON:
 
-```
-{
-  "store.custom#about-us": {
-    "path": "/about-us"
-  }
+```json
+"store.custom#{templatename}": {
+  "path": "/{URL}"
 }
 ```
 
 Save your files and link the theme to your workspace using the `vtex link` command. You will be able to access and see your new page through your workspace. 
 
-If the new page satisfies your store needs, [release](https://vtex.io/docs/recipes/store/releasing-a-new-app-version) your changes and [install](https://vtex.io/docs/recipes/store/installing-an-app) the new store's version in a [production workspace](https://vtex.io/docs/recipes/store/creating-a-production-workspace).   
+If the new page satisfies your store needs, [release](https://vtex.io/docs/recipes/store/releasing-a-new-app-version) your changes and [install](https://vtex.io/docs/recipes/store/installing-an-app) the new store's version in a [production workspace](https://vtex.io/docs/recipes/store/creating-a-production-workspace).
 
 #### Using the account admin
 
 If you prefer to set the new page path using account admin, you must first must [release](https://vtex.io/docs/recipes/store/releasing-a-new-app-version) your changes regarding template creation and [install](https://vtex.io/docs/recipes/store/installing-an-app) the new version of your store in a [production workspace](https://vtex.io/docs/recipes/store/creating-a-production-workspace).
 
-Then, simply access the **Pages** section and click on **Create New**. Afterwards, simply choose the desired URL and any created template. For instance, the About Us page template. 
+Then, simply access the **Pages** section and click on **Create New**. Afterwards, simply choose the desired URL and any created template. For instance, the About Us page template.
 
 ![custom-pages-pages](https://user-images.githubusercontent.com/52087100/64428903-36353900-d08b-11e9-8d19-186c8831b4d7.png)
 
-Notice that a template only sets the page layout, hence any new template becomes available to be set on any page that accepts templates of the same type as the page itself. 
+Notice that a template only sets the page layout, hence any new template becomes available to be set on any page that accepts templates of the same type as the page itself.
 
 <div class="alert alert-info">
 When editing any content using the CMS section, it's always good to make your changes in a production workspace. Therefore, make sure you are not creating your new custom page in the store's master workspace.
@@ -149,14 +147,14 @@ When editing any content using the CMS section, it's always good to make your ch
 
 ### Adding the content
 
-Your new page now has a custom layout, thanks to the newly created template, and can be accessed thanks to its route creation. The next step is editing its content. 
+Your new page now has a custom layout, thanks to the newly created template, and can be accessed thanks to its route creation. The next step is editing its content.
 
-In the account admin, access **Site Editor**, in CMS. You can browse to your custom page or simply write its URL in the `Page URL` field. 
+In the account admin, access **Site Editor**, in CMS. You can browse to your custom page or simply write its URL in the `Page URL` field.
 
 ![custom-pages-siteeditor](https://user-images.githubusercontent.com/52087100/64428904-36cdcf80-d08b-11e9-8de4-06bf0a89b14f.png)
 
-Once there, feel free to change its content by customizing the page's component. For more on possible customization, access our [Layout recipes](https://vtex.io/docs/recipes/layout) 
+Once there, feel free to change its content by customizing the page's component. For more on possible customization, access our [Layout recipes](https://vtex.io/docs/recipes/layout).
 
 ### Promoting to a master workspace 
 
-Finally, to make the new page available on your store, that is, available to end users, you must [promote your production workspace to master](https://vtex.io/docs/recipes/store/promoting-a-workspace-to-master) .
+Finally, to make the new page available on your store, that is, available to end users, you must [promote your production workspace to master](https://vtex.io/docs/recipes/store/promoting-a-workspace-to-master).

--- a/docs/en/Recipes/layout/using-sandbox-blocks.md
+++ b/docs/en/Recipes/layout/using-sandbox-blocks.md
@@ -7,12 +7,11 @@ version: "0.x"
 git: "https://github.com/vtex-apps/io-documentation/blob/master/docs/en/Recipes/layout/using-sandbox-blocks.md"
 ---
 
-
 # Using Sandbox blocks
 
 ## Introduction
 
-VTEX Store Framework is a very powerful tool meant to attend most client needs. It's understandable, though, that some custom requirements that your store needs and will not be served by the framework. That's where the **Sandbox App** comes in. 
+VTEX Store Framework is a very powerful tool meant to attend most client needs. It's understandable, though, that some custom requirements that your store needs and will not be served by the framework. That's where the **Sandbox App** comes in.
 
 The **Sandbox App** is basically a component that supports iFrames. Therefore, it allows you to use custom `html`, `css` and `js` code to customize your store.
 
@@ -24,14 +23,14 @@ The **Sandbox App** is basically a component that supports iFrames. Therefore, i
 
 2. Then, declare the Sandbox block in the `blocks` folder or in the `blocks.jsonc` file.
 
-```
+```json
 "sandbox#h1": {
-    "props": {
-        "width": "100%",
-        "height": "auto",
-        "initialContent": "<h1 style=\"text-align:center;\">Hello World</h1>",
-        "allowCookies": false
-    }
+  "props": {
+    "width": "100%",
+    "height": "auto",
+    "initialContent": "<h1 style=\"text-align:center;\">Hello World</h1>",
+    "allowCookies": false
+  }
 }
 ```
 
@@ -39,22 +38,21 @@ Let's suppose you want to create a simple `h1` sandbox block. It would look simi
 
 ![sanbox hello world](https://user-images.githubusercontent.com/19555647/64436924-ae0b5f80-d09b-11e9-9080-fd4c983689d1.png)
 
-
 3. Reference it in another's block `child dependency` or `blocks`. For instance, your `store.home`: 
 
-```
+```json
 //home.jsonc
 "store.home": {
-    "blocks": [
-      "carousel#home",
-      "sandbox#h1",
-      "flex-layout.row#deals",
-      "shelf#home",
-      "info-card#home",
-      "rich-text#question",
-      "rich-text#link",
-      "newsletter"
-    ]
+  "blocks": [
+    "carousel#home",
+    "sandbox#h1",
+    "flex-layout.row#deals",
+    "shelf#home",
+    "info-card#home",
+    "rich-text#question",
+    "rich-text#link",
+    "newsletter"
+  ]
 },
 ```
 

--- a/docs/en/Recipes/store/creating-a-production-workspace.md
+++ b/docs/en/Recipes/store/creating-a-production-workspace.md
@@ -15,7 +15,7 @@ Workspaces in production mode are ready to receive traffic, that is, to be acces
 
 You can create a production workspace simply using the following command: 
 
-```
+```sh
 vtex use {{workspacename}} --production
 ```
 

--- a/docs/en/Recipes/store/installing-the-google-tag-manager-app.md
+++ b/docs/en/Recipes/store/installing-the-google-tag-manager-app.md
@@ -43,13 +43,13 @@ To check or update the app's settings afterwards, simply visit the **Apps** sect
 
 1. Using your terminal, **login** to your account.
 
-```
+```sh
 vtex login {account}
 ```
 
 2. Access the account's desired **workspace**.
 
-```
+```sh
 vtex use {workspace}
 ```
 
@@ -57,7 +57,7 @@ You can confirm whether or not the GTM app is installed by running `vtex ls`.
 
 3. **Install** the GTM app.
 
-```
+```sh
 vtex install vtex.google-tag-manager@2.x
 ```
 
@@ -98,4 +98,3 @@ Check the full list of tags and variables that are blocked in VTEX IO Google Tag
 
 - Custom JavaScript Variable - `jsm`
 See a list with all the GTM available tags in the [Google Developer Guide](https://developers.google.com/tag-manager/devguide).
-

--- a/docs/en/Recipes/store/installing-the-vtex-io-toolbelt.md
+++ b/docs/en/Recipes/store/installing-the-vtex-io-toolbelt.md
@@ -19,12 +19,10 @@ To install the VTEX IO’s CLI, you need to ensure that [Node.js](https://nodejs
 
 Thereafter, type `yarn global add vtex` in your computer’s terminal.
 
-```
+```sh
 $ yarn global add vtex
 ```
 
 <div class="alert alert-info">
 To confirm that the installation occurred as expected, you can execute the <code>vtex</code> command. This should display all available commands in a help text. 
 </div>
-
-

--- a/docs/en/Recipes/store/making-your-new-app-version-publicly-available.md
+++ b/docs/en/Recipes/store/making-your-new-app-version-publicly-available.md
@@ -29,11 +29,10 @@ You can use the <code>vtex publish</code> command to make your app beta version 
 
 ## Production workspace
 
-In order to install and test your beta app version, you must create a workspace in production mode using the following command: 
+In order to install and test your beta app version, you must create a workspace in production mode using the following command:
 
-```
+```sh
 vtex use {{workspacename}} --production
-
 ```
 
 <div class="alert alert-warning">
@@ -49,14 +48,16 @@ To install an app in the new production workspace, simply run one of the followi
 Once the **beta** app has been installed and tested in the production workspace, you can run `vtex release {major/minor/patch} stable` in your terminal to automatically make an app **stable** version ready for installation.
 
 Having completed the above, simple follow the app installation steps to finally install the app **stable** version in your production workspace.
- 
+
 ## Master workspace
 
 Promoting a workspace to master means making any changes performed in it available to the end user, in other words, making your new app version publicly available.
 
 You can promote your production mode workspace to master using the following command:
 
-`vtex workspace promote`
+```sh
+vtex workspace promote
+```
 
 <div class="alert alert-info">
 The status of a workspace in master is <code>production true</code>.

--- a/docs/en/Recipes/store/overwriting-the-messages-app.md
+++ b/docs/en/Recipes/store/overwriting-the-messages-app.md
@@ -28,7 +28,7 @@ This recipe will show you how to overwrite the Messages app and easily create ne
 3. From the dropdown list, choose the `vtex.messages` app.
 4. Write the following mutation command in the text box that is displayed:
 
-```
+```graphql
 mutation Save($args: SaveArgsV2!) {
   saveV2(args: $args)
 }
@@ -39,7 +39,7 @@ mutation Save($args: SaveArgsV2!) {
 
 ### For the store's catalog translations
 
-```
+```json
 {
   "args": {
     "to": "en-US",
@@ -65,7 +65,7 @@ mutation Save($args: SaveArgsV2!) {
 
 ### For app messages translation:
 
-```
+```json
 {
   "args": {
     "to": "en-US",
@@ -84,12 +84,12 @@ mutation Save($args: SaveArgsV2!) {
 **These variables are flexible and must match your store's desired scenario**. The variables for app message translations are as follows:
 
 - `to`: target translation locale.
-- `srcLang`: source message locale. This variable must contain the value `en-DV`, no matter which locale is rendered on the app's interface. 
+- `srcLang`: source message locale. This variable must contain the value `en-DV`, no matter which locale is rendered on the app's interface.
 - `srcMessage`: source message string.  
 - `targetMessage`: message translation string.
-- `context`: message translation context, meaning the name of the app in which the Messages are being overwritten. 
+- `context`: message translation context, meaning the name of the app in which the Messages are being overwritten.
 
-Following the given example above, your admin should look similar to this: 
+Following the given example above, your admin should look similar to this:
 
 ![recipe-messages-overwriting](https://user-images.githubusercontent.com/52087100/68410089-eb0cd480-0166-11ea-89bf-217aa7994b91.png)
 
@@ -97,7 +97,7 @@ Finally, click on the play button to run the declared mutation.
 
 The expected response is as follows:
 
-```
+```json
 {
   "data": {
     "saveV2": true

--- a/docs/en/Recipes/style/using-css-handles-for-store-customization.md
+++ b/docs/en/Recipes/style/using-css-handles-for-store-customization.md
@@ -25,13 +25,13 @@ During the inspection, bear in mind your store's following **component identific
 
 ![component-id-structure](https://user-images.githubusercontent.com/52087100/67318281-adab1480-f4e1-11e9-9c8f-c20b8f0647ec.png)
 
-2. In your store theme code, create a file inside the `css` folder, giving it the name of the app in which the inspected component is defined and adding `vtex.` as the beginning of the name and `.css` at the end, such as `vtex.store-components.css`. 
+2. In your store theme code, create a file inside the `css` folder, giving it the name of the app in which the inspected component is defined and adding `vtex.` as the beginning of the name and `.css` at the end, such as `vtex.store-components.css`.
 3. In the recently created file, declare the component's CSS Handle, taking into account the following format: 
 
-```
+```css
 .{CSSHandleName} {  
-{CSSClass1}: {DesiredValue};
-{CSSClass2}: {DesiredValue};  
+  {CSSClass1}: {DesiredValue};
+  {CSSClass2}: {DesiredValue};  
 }
 ```
 


### PR DESCRIPTION
This should solve rendering issues at vtex.io/docs regarding code blocks with no `language`.