### PR TITLE
Update how to translate Catalog messages

### DIFF
--- a/docs/en/Recipes/store/overwriting-the-messages-app.md
+++ b/docs/en/Recipes/store/overwriting-the-messages-app.md
@@ -46,8 +46,8 @@ mutation Save($args: SaveArgsV2!) {
     "messages": [
       {
         "srcLang": "pt-BR",
-        "srcMessage": "Meu produto maneiro em Portugues",
-        "targetMessage": "My awesome product in English",
+        "srcMessage": "Nome do produto em português",
+        "targetMessage": "Product's name in english",
         "context": "543123"
       }
     ]

--- a/docs/en/Recipes/store/overwriting-the-messages-app.md
+++ b/docs/en/Recipes/store/overwriting-the-messages-app.md
@@ -46,9 +46,9 @@ mutation Save($args: SaveArgsV2!) {
     "messages": [
       {
         "srcLang": "pt-BR",
-        "srcMessage": "Bem vindo! Faça seu Login.",
-        "targetMessage": "Welcome! Please, log in. ",
-        "context": "vtex.login@2.x"
+        "srcMessage": "Meu produto maneiro em Portugues",
+        "targetMessage": "My awesome product in English",
+        "context": "543123"
       }
     ]
   }
@@ -61,7 +61,7 @@ mutation Save($args: SaveArgsV2!) {
 - `srcLang`: source message locale.
 - `srcMessage`: source message string.
 - `targetMessage`: message translation string.
-- `context`: message translation context. This variable is not mandatory and only serves to give Messages the context desired for the translation, since the same word can have different meaning depending on the language. If you want o use this variable, you'll have to add, between 3 parenthesis, the desired context to the product name, in the admin's catalog. I.e:  `Mouse (((rodent)))`. The desired value will therefore not be displayed next to the product name and will only be used to the catalog translation.
+- `context`: message translation context. This variable is required for product/brand/category/specification and are their respective Ids so their translations are well scoped.
 
 ### For app messages translation:
 

--- a/docs/en/Recipes/store/overwriting-the-messages-app.md
+++ b/docs/en/Recipes/store/overwriting-the-messages-app.md
@@ -61,7 +61,7 @@ mutation Save($args: SaveArgsV2!) {
 - `srcLang`: source message locale.
 - `srcMessage`: source message string.
 - `targetMessage`: message translation string.
-- `context`: message translation context. This variable is required for product/brand/category/specification and are their respective Ids so their translations are well scoped.
+- `context`: ID responsible for providing context, based on the Catalog data, about the source message string being translated. Each product/brand/category/specification in your store has a unique ID that can be found in its registration on the admin's Catalog. 
 
 ### For app messages translation:
 


### PR DESCRIPTION
We now have a new way of defining the context of a product translation. This PR updates this doc accordingly and improves the example

**What problem is this solving?**

<!--- What is the motivation and context for this change? -->

**How should this be manually tested?**

**Screenshots or example usage:**