### PR TITLE
Add link to next article because it's almost invisible

### DIFF
--- a/docs/en/GettingStarted/develop-native-integrations-with-pixel-apps/1-DevelopNativeIntegrationsWithPixelApps.md
+++ b/docs/en/GettingStarted/develop-native-integrations-with-pixel-apps/1-DevelopNativeIntegrationsWithPixelApps.md
@@ -7,3 +7,5 @@ It is possible, however, that the integration you’re looking for is not curren
 In the following steps of this track, you will learn all the necessary steps to leverage from the new integration, thereby **developing a Pixel app according to your store's own needs**. 
 
 > ℹ️ *If you’re unsure whether to proceed with developing a pixel app or to customize an HTML tag using Google Tag Manager, keep in mind that the first option is always the most recommended. Developing an new app will enable a bold integration process with a third party solution, in addition to further evolving the Framework to help other users that may be interested in the same integration.*
+
+[Next article](https://vtex.io/docs/getting-started/develop-native-integrations-with-pixel-apps/2/)


### PR DESCRIPTION
I almost can't see the link to the next article, it seems that it ended there

![image](https://user-images.githubusercontent.com/284515/98045557-6ef3ae00-1e07-11eb-93bc-070430ec8334.png)
