### PR TITLE
Update 2-SetupBasicoParaDesenvolverNoVTEXIO.md

### DIFF
--- a/docs/pt/GettingStarted/build-stores-with-vtex-io/2-SetupBasicoParaDesenvolverNoVTEXIO.md
+++ b/docs/pt/GettingStarted/build-stores-with-vtex-io/2-SetupBasicoParaDesenvolverNoVTEXIO.md
@@ -1,38 +1,40 @@
-# *Setup* básico para desenvolver no VTEX IO
+# Setup básico para desenvolver no VTEX IO
 
-Todo desenvolvimento no VTEX IO começa com o [**Toolbelt**](*link*), nossa CLI (Command Line Interface) que permite fazer login, desenvolver novas [apps](*link*) e gerenciar as já instaladas.
+Todo desenvolvimento no VTEX IO começa com o **[Toolbelt](*link*)**, a Command Line Interface (CLI) - também conhecida como Interface de linha de comando - que permite fazer login, desenvolver novos [apps](*link*) e gerenciar os já instalados.
 
-## VTEX IO Toolbelt
+## Instalando VTEX IO Toolbelt
 
 Para instalar a CLI do VTEX IO, você precisa garantir que o seu computador tenha o [Node.js](https://nodejs.org/) e o [Yarn](https://yarnpkg.com/) instalados.
 
-Em seguida, digite `yarn global add vtex` no terminal do seu computador.
+Em seguida, digite no terminal do seu computador:
 
 ```
 $ yarn global add vtex
 ```
 
->ℹ️ *Para confirmar que a instalação ocorreu normalmente, você pode executar o comando `vtex`. Ele deverá mostrar um texto de ajuda com todos os comandos disponíveis.*
+> ℹ️ Para confirmar que a instalação ocorreu normalmente, você pode executar o comando `vtex`. Ele deverá mostrar um texto de ajuda com todos os comandos disponíveis.
 
-## Login
+## Fazendo Login
 
-Com a CLI do VTEX IO instalada, use o comando `vtex login para entrar na sua conta VTEX:
+Com a CLI do VTEX IO instalada, digite o comando abaixo para fazer o login na sua conta VTEX:
 
 ```
 $ vtex login {ContaVTEX}
 ```
 
-Isso abrirá uma janela do seu navegador que solicitará suas credenciais.
+Isso abrirá uma janela do seu navegador, solicitando suas credenciais.
 
-Quando já estiver *logado*, você pode usar o comando `vtex whoami` para descobrir qual conta e *workspace* estão sendo usados pelo terminal.
+Após acessar sua conta, você pode usar o comando `vtex whoami` para descobrir qual conta e workspace estão sendo usados pelo terminal.
 
-![]("https://user-images.githubusercontent.com/52087100/61886028-517e2780-aed5-11e9-9398-b6d2f3909a50.png"
+![Exemplo de conta e workspace usados pelo terminal](https://user-images.githubusercontent.com/52087100/61886028-517e2780-aed5-11e9-9398-b6d2f3909a50.png)
   
-## Criando seu próprio *workspace*
+## Criando seu próprio workspace
 
-Ao usar o VTEX IO, toda interação com uma conta acontece em um [***workspace***](*link*).
+Ao usar o VTEX IO, toda interação com uma conta acontece em um ***[workspace](*link*)***. O *workspace* é um ambiente de trabalho individual, o qual você faz alterações sem comprometer outros ambientes.
 
-Ao fazer *login* em uma loja, você está automaticamente no *workspace* master dela, ou seja, na versão disponível para o usuário final. Por isso, lembre-se que sempre que você quiser testar uma nova configuração, o seu próprio *workspace* de desenvolvimento deve ser criado usando o comando `vtex use`.
+Ao fazer login em uma loja, você está automaticamente no *workspace* master dela, ou seja, na versão disponível para o usuário final. 
+
+Lembre-se, que sempre que você quiser testar uma nova configuração, o seu próprio *workspace* de desenvolvimento deve ser criado usando o comando a seguir:
 
 ```
 $ vtex use {nomeexemplo}
@@ -42,7 +44,7 @@ Isso muda o seu Toolbelt para um *workspace* chamado `nomeexemplo` e o cria se e
 
 ![vtex-use-nomeexemplo](https://user-images.githubusercontent.com/52087100/61886135-7ffc0280-aed5-11e9-983f-4a76615d0574.png)
 
->⚠️ *O `vtex use` faz com que todas as suas operações passem a ocorrer no `workspace` definido no comando. Isso significa que é possível alternar suas operações para master apenas executando no Toolbelt `vtex use master`, por exemplo.*
+>⚠️ O `vtex use` faz com que todas as suas operações passem a ocorrer no `workspace` definido no comando. Isso significa que é possível alternar suas operações para master apenas executando no Toolbelt `vtex use master`, por exemplo.
 
 Com o seu próprio *workspace* de desenvolvimento criado, você pode navegar na sua loja acessando:
 
@@ -50,4 +52,4 @@ Com o seu próprio *workspace* de desenvolvimento criado, você pode navegar na 
 
 Onde `workspace` é o *workspace* que você acabou de criar (como `nomeexemplo`) e `conta` é o nome da conta em que você está trabalhando.
 
-Pronto! Agora você já pode desenvolver sua loja no VTEX IO.
+Agora você já pode desenvolver sua loja no VTEX IO.


### PR DESCRIPTION
 Sugestões para implementação.

**What problem is this solving?**
Suggestions about _Markdown_ issues, content structure and replacing some words.

<!--- What is the motivation and context for this change? -->
According to the purpose of the week's activity, for the Black Tech Writers course, I've analyzed and here are some suggestions:

1. Line 1:  As part of the title, we can change the word 'Setup' font style to non-italic and perhaps, translate the word to Portuguese - to be more specific about the documentation content.

2. Line 3: according to [this guide](http://sumo.pe/blog/guia-markdown.html#formatting-links), the '**' should envolve the name and the link's name.

3. Line 5: I suggested a change in the subtitle to make it clear what the section is about.

4. Line 9: Perhaps, type the command `yarn global add vtex` only once.

5.  Line 19: we can remove ` vtex login` and type ` vtex login {ContaVTEX}` below.

6. Line 25: Adding an explanation about what to expect and what to do after finishing the command, can make things clear to the user.

7. Line 29: You can change the image link to:  `![Exemplo de conta e workspace usados pelo terminal](https://user-images.githubusercontent.com/52087100/61886028-517e2780-aed5-11e9-9398-b6d2f3909a50.png)`. Therefore, the user can see it properly. The code's outcome is the picture below:
![Exemplo de conta e workspace usados pelo terminal](https://user-images.githubusercontent.com/52087100/61886028-517e2780-aed5-11e9-9398-b6d2f3909a50.png)

8. Line 33: I just added an explanation about _workspace_, to make sure the user understands its purposes.

9. Line 35: I made a suggestion about breaking in two paragraphs, to achieve a more pleasant reading.
