### PR TITLE
Fix broken markdown

### DIFF
--- a/docs/en/Recipes/development/developing-custom-storefront-components.md
+++ b/docs/en/Recipes/development/developing-custom-storefront-components.md
@@ -206,7 +206,7 @@ In terms of content internationalization, be cautious with string text translati
 
 Be aware that internationalization can mean more than string text translations! Take care of interpolation, pluralization, price and percentage formatting, among other discrepancies that may come into your way once borders are crossed.
 
-Read the [Translating the component]() article and the [multi-language store documentations](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-multi-language-stores) to understand how you can make these adjustments in your component! 
+Read the [Translating the component](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-8-translating-the-component) article and the [multi-language store documentations](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-multi-language-stores) to understand how you can make these adjustments in your component! 
 
 ## Styling
 
@@ -218,7 +218,7 @@ Understand both tools' particularities to make the best decision for your compon
 
 Also, do not forget to make CSS Handles available for your component users if its distribution is a goal. Through Handles, future users will be able to style your storefront component as desired, according to their own specific needs. 
 
-Check out the documentation on [Defining styles]() to learn about Tachyons, CSS Modules and CSS Handles, as well as their use cases.
+Check out the documentation on [Defining styles](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-5-defining-styles) to learn about Tachyons, CSS Modules and CSS Handles, as well as their use cases.
 
 Another good styling tip is to be careful with the breakpoints on the screen according to devices. Remember to set the component style for every possible scenario on the interface!
 

--- a/docs/en/Recipes/development/developing-custom-storefront-components.md
+++ b/docs/en/Recipes/development/developing-custom-storefront-components.md
@@ -23,7 +23,7 @@ When creating a custom component, use tools to ease the code development by auto
 
 Features such as [ESLint](https://eslint.org/), [Typescript](https://www.typescriptlang.org/), and [Prettier](https://prettier.io/) are not mandatory for project deployment, but they help development, code maintenance, and testings. 
 
-The [React App repository(https://github.com/vtex-apps/react-app-template) is the go-to model template for tooling since it provides formatting features and the [VTEX Test Tool](https://github.com/vtex/test-tools), a native testing tool from VTEX that leverages from [Jest](https://jestjs.io/).
+The [React App repository](https://github.com/vtex-apps/react-app-template) is the go-to model template for tooling since it provides formatting features and the [VTEX Test Tool](https://github.com/vtex/test-tools), a native testing tool from VTEX that leverages from [Jest](https://jestjs.io/).
 
 Use Typescript types as an ally in your development journey since they provide autocomplete tools that can be used when developing and importing a new component. To have them at hands, run the following command in your terminal: 
 


### PR DESCRIPTION
Link wasn't rendering correctly:

https://vtex.slack.com/archives/CTW0F5JCQ/p1615825155055900

*BEFORE*

> The [React App repository(https://github.com/vtex-apps/react-app-template) is the go-to model template ...

*AFTER*

> The [React App repository](https://github.com/vtex-apps/react-app-template) is the go-to model template ...

**What problem is this solving?**

Markdown was broken

**How should this be manually tested?**

No need to test, changes were fixed in Readme... Just need to make sure they are incorporated to Github as well.