### PR TITLE
Update vtex-io-cli-installation-and-command-reference.md

### DIFF
--- a/docs/en/Recipes/development/vtex-io-cli-installation-and-command-reference.md
+++ b/docs/en/Recipes/development/vtex-io-cli-installation-and-command-reference.md
@@ -38,7 +38,7 @@ By not adding the Yarn binaries to terminal `PATH`, Yarn and its programs can't 
 #### Workaround for MacOS and Linux users
 
 1. In your local directories, find the Profile file. It is usually hidden and is named after the command line's interpreter. For example: If you're using `bash`, your Profile file will be named `bashrc`. If you use `zsh`, it will be `zshrc`;
-2. Once in the Profile file, add the following command: `export PATH="$PATH: yarn global bin"`;
+2. Once in the Profile file, add the following command: `export PATH=$PATH:$(yarn global bin)`;
 3. Log in and log out of your terminal for the changes to take effect; 
 
 <div class="alert alert-info">  


### PR DESCRIPTION
Adding suggested edit to Github:

https://dash.readme.com/project/vtex-developer-docs/v2.1/suggested/update/605a5f1ec15f0200653a884c

**What problem is this solving?**

Small typo in export path command

**How should this be manually tested?**

No need

**Screenshots or example usage:**

No screenshots