### PR TITLE
Fix typo that brakes the integration

### DIFF
--- a/docs/en/Recipes/store-management/setting-up-google-tag-manager.md
+++ b/docs/en/Recipes/store-management/setting-up-google-tag-manager.md
@@ -83,7 +83,7 @@ For this, click on **Fields to Set**, and then add the field `userId` with its d
 
 |  Field name     |                 Value                    |   
 |-----------------|------------------------------------------| 
-|  `campaingName`   | {Data Layer Variable - campaignName}   |
+|  `campaignName`   | {Data Layer Variable - campaignName}   |
 |  `campaignMedium` | {Data Layer Variable - campaignMedium} |
 |  `campaignSource` | {Data Layer Variable - campaignSource} |
 


### PR DESCRIPTION
Fix `campaingName` to `campaignName`

**What problem is this solving?**

There was as typo in the documentation for setting up Google Tag Manager.