### PR TITLE
Revert "sponsor account and VTEX IO'S CLI link fixed"

### DIFF
--- a/docs/en/Recipes/development/configuring-an-edition-app.md
+++ b/docs/en/Recipes/development/configuring-an-edition-app.md
@@ -13,13 +13,13 @@ The hierarchical relationship between a [Sponsor Account](https://vtex.io/docs/c
 
 Hence, it can be advantageous for **complex account families** under the same brand or holding to have its own Edition App.
 
-Once you [enable the Sponsor Account behavior](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-becoming-a-sponsor-account) in one of your accounts, follow the steps below to create your own Edition app and install it on your child accounts.
+Once you [enable the Sponsor Account behavior](https://vtex.io/docs/recipes/development/becoming-a-sponsor-account) in one of your accounts, follow the steps below to create your own Edition app and install it on your child accounts.
 
 ## Step by step
 
 ### Step 1 - Creating an Edition app
 
-1. Using your terminal and [VTEX IO's CLI](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-toolbelt), log in to your Sponsor Account.
+1. Using your terminal and [VTEX IO's CLI](https://developers.vtex.com/vtex-developer-docs/docs/toolbelt), log in to your Sponsor Account.
 2. Run the `vtex init` command.
 3. Choose the `edition app` option. This will create a boilerplate repository in your local files.
 4. Navigate to the `edition-app` folder and open the `manifest.json` file. It should look something like this:


### PR DESCRIPTION
Reverts vtex-apps/io-documentation#887

**What problem is this solving?**
It fixes the 404 error on the links at "enable the Sponsor Account behavior" and at  "VTEX IO's CLI".

<!--- What is the motivation and context for this change? -->
According to the feedback in [EDU-3803](https://vtex-dev.atlassian.net/browse/EDU-3803)

**How should this be manually tested?**

1. Open your code editor.
2. Go to the folder **docs** > **en** > **Recipes** > **development.**
3. In the folder **development**, click on the file **configuring-an-edition-app.md.**
4. Go to the 16th line of the document.
5. Mouseover on the link https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-becoming-a-sponsor-account
6. Click **Follow link** 
7. Click **Open**
8. and check if redirects you to the page [Becoming a Sponsor Account](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-becoming-a-sponsor-account)
9. Go back to the document in your code editor
8. Go to the 22nd line of the document.
9. Mouseover on the link https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-toolbelt.
10. Click on **Follow link** 
11. Click **Open**
11. Check if redirects you to the page [VTEX IO CLI](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-toolbelt)

**Screenshots or example usage:**
[Manually testing video?](https://www.loom.com/share/b7ca110d40dc46df927463031b5253fd)