### PR TITLE
Release v0.64.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.64.18] - 2021-05-18
+
 ## [0.64.17] - 2021-05-18
 
 ## [0.64.16] - 2021-05-07

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "io-documentation",
-  "version": "0.64.17",
+  "version": "0.64.18",
   "title": "VTEX IO Documentation",
   "description": "VTEX IO Documentation",
   "builders": {


### PR DESCRIPTION
**What problem is this solving?**

It fixes the 404 error on the links at "enable the Sponsor Account behavior" and at  "VTEX IO's CLI".

<!--- What is the motivation and context for this change? -->
According to the feedback in [EDU-3803](https://vtex-dev.atlassian.net/browse/EDU-3803)

**How should this be manually tested?**

**Screenshots or example usage:**