### PR TITLE
fix: campaignName typo on Setting up GTM

### DIFF
--- a/docs/en/Recipes/store-management/setting-up-google-tag-manager.md
+++ b/docs/en/Recipes/store-management/setting-up-google-tag-manager.md
@@ -83,7 +83,7 @@ For this, click on **Fields to Set**, and then add the field `userId` with its d
 
 |  Field name     |                 Value                    |   
 |-----------------|------------------------------------------| 
-|  `campaingName`   | {Data Layer Variable - campaignName}   |
+|  `campaignName`   | {Data Layer Variable - campaignName}   |
 |  `campaignMedium` | {Data Layer Variable - campaignMedium} |
 |  `campaignSource` | {Data Layer Variable - campaignSource} |
 


### PR DESCRIPTION
**What problem is this solving?**

This solves a typo on the Setting up GTM doc that could make information go missing after cart navigation.
