### PR TITLE
add segmenting search result recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `Segmenting search result` recipe.
+
 ## [0.86.29] - 2021-12-28
 
 ## [0.86.28] - 2021-12-23

--- a/docs/en/Recipes/store-management/segmenting-the-search-result.md
+++ b/docs/en/Recipes/store-management/segmenting-the-search-result.md
@@ -34,7 +34,7 @@ interface SearchSegmentInput {
     userEmail?: string
     // Whether the user is authenticated or not.
     isAuthenticated?: boolean
-    // Arrrao of selected facets (optionally you can control it by the session itself)
+    // Array of selected facets (optionally you can control it by the session itself)
     selectedFacets?: SelectedFacet[]
 }
 ```

--- a/docs/en/Recipes/store-management/segmenting-the-search-result.md
+++ b/docs/en/Recipes/store-management/segmenting-the-search-result.md
@@ -1,0 +1,70 @@
+---
+title: Segmenting the search result
+description: "Sometimes you want search results to be segmented by user information, like email, for example. This guide will help you with that."
+date: "2021-11-29"
+tags: ["segment", "search", "b2b"]
+version: "0.x"
+git: "https://github.com/vtex-apps/io-documentation/blob/master/docs/en/Recipes/store-management/segmenting-the-search-result.md"
+---
+
+# Segmenting the search result
+
+In some situations, especially in B2B accounts, it is necessary to segment the products that will appear to the user based on information, such as email.
+See the example below. For each user entered, the search result is different.
+
+## Setup
+Creating segmentation rules is easy and customizable. First of all, install the following apps in your test workspace.
+```
+vtex.search-session@0.x
+vtex.search-segment-graphql@0.x
+```
+The `vtex.search-session` is responsible for managing the user session, while the `vtex.search-segment-graphql` is where the GraphQL schema is declared.
+
+Now, clone the [`vtex.search-segment-resolver`](https://github.com/vtex-apps/search-segment-resolver) project. This project is just a boilerplate and you will edit it however you like. You just need to follow these steps:
+
+1. Go to the `manifest.json` and change the `vendor` to your own account.
+
+2. Change the implementation of the `searchSegment` function on `node/resolvers/segmentSearch.ts` file. The `searchSegment` receives a variable called `args`, and has the following interface:
+
+```ts
+interface SearchSegmentInput {
+    // User email
+    userEmail?: string
+    // Whether the user is authenticated or not.
+    isAuthenticated?: boolean
+    // Arrrao of selected facets (optionally you can control it by the session itself)
+    selectedFacets?: SelectedFacet[]
+}
+```
+
+The `searchSegment` function output has the following interface:
+
+```json
+[
+    {
+        "key": "mykey",
+        "value": "myValue"
+    }
+]
+```
+
+It's just an array of facets. For example, if you want to segment the search by the category "shoes", the function needs to return `[{"key": "category-1", "value": "shoes"}]`.
+
+If you want to segment by email domain, for example, the function would be something like this:
+
+```ts
+export const queries = {
+  searchSegment: async (ctx: any, args: SearchSegmentInput, __: Context) => {
+    const userEmail = args.userEmail
+    const domain = userEmail.split('@')[1]
+
+    return domain === 'vtex.com.br' ? [{ key: 'productClusterIds', value: '123' }] : [{ key: 'productClusterIds', value: '456' }]
+  },
+}
+```
+In this example, if the email has the `vtex.com.br` domain it will filter by the collection `123`, otherwise, it will filter by `456`.
+
+3. Link your app to your test workspace. Make sure everything is working fine.
+
+4. Now you can release, deploy and install the app on your production workspace.
+

--- a/docs/en/Recipes/store-management/segmenting-the-search-result.md
+++ b/docs/en/Recipes/store-management/segmenting-the-search-result.md
@@ -19,8 +19,10 @@ Take the following example in which different results for the same search are ob
 To create segmented search results, we'll create a new VTEX IO app from the [`vtex.search-segment-resolver`](https://github.com/vtex-apps/search-segment-resolver) boilerplate and customize it to establish our own segmentation rules.
 
 1. Clone the `vtex.search-segment-resolver` app into your machine:
+
   ```sh
   git clone https://github.com/vtex-apps/search-segment-resolver
+  ```
 
 2. Open the `search-segment-resolver` project in any code editor of your preference.
 3. Go to the `manifest.json` file and replace the `vendor` value with the name of your VTEX account.
@@ -39,6 +41,7 @@ export const queries = {
   },
 }
 ```
+
  Notice that the `searchSegment` function receives the `args` variable, which has the `SearchSegmentInput` type: 
  
  ```ts
@@ -50,6 +53,8 @@ interface SearchSegmentInput {
     // Array of selected facets (optionally you can control it by the session itself)
     selectedFacets?: SelectedFacet[]
 }
+```
+
 6. [Create a development workspace](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-creating-a-development-workspace) and [link your app](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-linking-an-app) to test if your segmentation rules are working as expected.
 7. Once you finish your tests, follow all the necessary steps to [make your app publicly available](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-making-your-new-app-version-publicly-available) before promoting it to master.
 

--- a/docs/en/Recipes/store-management/segmenting-the-search-result.md
+++ b/docs/en/Recipes/store-management/segmenting-the-search-result.md
@@ -12,6 +12,8 @@ git: "https://github.com/vtex-apps/io-documentation/blob/master/docs/en/Recipes/
 In some situations, especially in B2B accounts, it is necessary to segment the products that will appear to the user based on information, such as email.
 See the example below. For each user entered, the search result is different.
 
+![Segmented Catalog B2B](https://user-images.githubusercontent.com/40380674/143891928-0865937e-c4f6-4a07-9448-0a723fce580b.gif)
+
 ## Setup
 Creating segmentation rules is easy and customizable. First of all, install the following apps in your test workspace.
 ```

--- a/docs/en/Recipes/store-management/segmenting-the-search-result.md
+++ b/docs/en/Recipes/store-management/segmenting-the-search-result.md
@@ -9,43 +9,25 @@ git: "https://github.com/vtex-apps/io-documentation/blob/master/docs/en/Recipes/
 
 # Segmenting the search result
 
-In some situations, especially in B2B accounts, it is necessary to segment the products that will appear to the user based on information, such as email.
-See the example below. For each user entered, the search result is different.
+In some situations, especially in B2B accounts, you may want to present custom search results for each of your customers. To this end, this tutorial will guide you on how to segment the search result page of your store.
+
+Take the following example in which different results for the same search are obtained based on the customer's email.
 
 ![Segmented Catalog B2B](https://user-images.githubusercontent.com/40380674/143891928-0865937e-c4f6-4a07-9448-0a723fce580b.gif)
 
-## Setup
-Creating segmentation rules is easy and customizable. First of all clone the [`vtex.search-segment-resolver`](https://github.com/vtex-apps/search-segment-resolver) project. This project is just a boilerplate and you will edit it however you like. You just need to follow these steps:
+## Step by step
+To create segmented search results, we'll create a new VTEX IO app from the [`vtex.search-segment-resolver`](https://github.com/vtex-apps/search-segment-resolver) boilerplate and customize it to establish our own segmentation rules.
 
-1. Go to the `manifest.json` and change the `vendor` to your own account.
+1. Clone the `vtex.search-segment-resolver` app into your machine:
+  ```sh
+  git clone https://github.com/vtex-apps/search-segment-resolver
 
-2. Change the implementation of the `searchSegment` function on `node/resolvers/segmentSearch.ts` file. The `searchSegment` receives a variable called `args`, and has the following interface:
+2. Open the `search-segment-resolver` project in any code editor of your preference.
+3. Go to the `manifest.json` file and replace the `vendor` value with the name of your VTEX account.
+4. Go to the `node/resolvers` folder and open the `searchSegment.ts` file. 
 
-```ts
-interface SearchSegmentInput {
-    // User email
-    userEmail?: string
-    // Whether the user is authenticated or not.
-    isAuthenticated?: boolean
-    // Array of selected facets (optionally you can control it by the session itself)
-    selectedFacets?: SelectedFacet[]
-}
-```
-
-The `searchSegment` function output has the following interface:
-
-```json
-[
-    {
-        "key": "mykey",
-        "value": "myValue"
-    }
-]
-```
-
-It's just an array of facets. For example, if you want to segment the search by the category "shoes", the function needs to return `[{"key": "category-1", "value": "shoes"}]`.
-
-If you want to segment by email domain, for example, the function would be something like this:
+   >ℹ️ The `segmentSearch` function is responsible for providing a JSON array of facets. For example, if you want to segment the search by the `shoes` category, the `segmentSearch` functio returns `[{"key": "category-1", "value": "shoes"}]`.
+5. Replace the `searchSegment` definition with your own segmentation rules. Take the following example in which we segmented the search result to filter by the `123`collection for `vtex.com.br` emails and by the `456` collection otherwise:
 
 ```ts
 export const queries = {
@@ -57,9 +39,17 @@ export const queries = {
   },
 }
 ```
-In this example, if the email has the `vtex.com.br` domain it will filter by the collection `123`, otherwise, it will filter by `456`.
-
-3. Link your app to your test workspace. Make sure everything is working fine.
-
-4. Now you can release, deploy and install the app on your production workspace.
+ Notice that the `searchSegment` function receives the `args` variable, which has the `SearchSegmentInput` type: 
+ 
+ ```ts
+interface SearchSegmentInput {
+    // User email
+    userEmail?: string
+    // Whether the user is authenticated or not.
+    isAuthenticated?: boolean
+    // Array of selected facets (optionally you can control it by the session itself)
+    selectedFacets?: SelectedFacet[]
+}
+6. [Create a development workspace](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-creating-a-development-workspace) and [link your app](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-linking-an-app) to test if your segmentation rules are working as expected.
+7. Once you finish your tests, follow all the necessary steps to [make your app publicly available](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-making-your-new-app-version-publicly-available) before promoting it to master.
 

--- a/docs/en/Recipes/store-management/segmenting-the-search-result.md
+++ b/docs/en/Recipes/store-management/segmenting-the-search-result.md
@@ -15,14 +15,7 @@ See the example below. For each user entered, the search result is different.
 ![Segmented Catalog B2B](https://user-images.githubusercontent.com/40380674/143891928-0865937e-c4f6-4a07-9448-0a723fce580b.gif)
 
 ## Setup
-Creating segmentation rules is easy and customizable. First of all, install the following apps in your test workspace.
-```
-vtex.search-session@0.x
-vtex.search-segment-graphql@0.x
-```
-The `vtex.search-session` is responsible for managing the user session, while the `vtex.search-segment-graphql` is where the GraphQL schema is declared.
-
-Now, clone the [`vtex.search-segment-resolver`](https://github.com/vtex-apps/search-segment-resolver) project. This project is just a boilerplate and you will edit it however you like. You just need to follow these steps:
+Creating segmentation rules is easy and customizable. First of all clone the [`vtex.search-segment-resolver`](https://github.com/vtex-apps/search-segment-resolver) project. This project is just a boilerplate and you will edit it however you like. You just need to follow these steps:
 
 1. Go to the `manifest.json` and change the `vendor` to your own account.
 


### PR DESCRIPTION
**What problem is this solving?**

The S&P team released a new feature called "Segmented search". It basically filters the search-result based on user Information. This PR adds a new recipe to guide the customer in implementing this functionality.
**How should this be manually tested?**

**Screenshots or example usage:
![Segmented Catalog B2B](https://user-images.githubusercontent.com/40380674/143891928-0865937e-c4f6-4a07-9448-0a723fce580b.gif)
**