### PR TITLE
btwrenanramires

### DIFF
--- a/docs/pt/GettingStarted/build-stores-with-vtex-io/2-SetupBasicoParaDesenvolverNoVTEXIO.md
+++ b/docs/pt/GettingStarted/build-stores-with-vtex-io/2-SetupBasicoParaDesenvolverNoVTEXIO.md
@@ -1,10 +1,10 @@
 # *Setup* básico para desenvolver no VTEX IO
 
-Todo desenvolvimento no VTEX IO começa com o [**VTEX IO CLI**](*link*), nossa CLI (Command Line Interface) que permite fazer login, desenvolver novas [apps](*link*) e gerenciar as já instaladas.
+Todo desenvolvimento no `VTEX IO` começa com o [**VTEX IO CLI**](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-vtex-io-cli-installation-and-command-reference), nossa *CLI (Command Line Interface*) que permite fazer *login*, desenvolver novas *apps* e gerenciar as já instaladas.
 
 ## VTEX IO CLI
 
-Para instalar a CLI do VTEX IO, você precisa garantir que o seu computador tenha o [Node.js](https://nodejs.org/) e o [Yarn](https://yarnpkg.com/) instalados.
+Para instalar a *CLI* do `VTEX IO`, você precisa garantir que o seu computador tenha o [Node.js](https://nodejs.org/) e o [Yarn](https://yarnpkg.com/) instalados.
 
 Em seguida, digite `yarn global add vtex` no terminal do seu computador.
 
@@ -16,7 +16,7 @@ $ yarn global add vtex
 
 ## Login
 
-Com a CLI do VTEX IO instalada, use o comando `vtex login para entrar na sua conta VTEX:
+Com a *CLI* do `VTEX IO` instalada, use o comando `vtex login` para entrar na sua conta VTEX:
 
 ```
 $ vtex login {ContaVTEX}
@@ -26,23 +26,23 @@ Isso abrirá uma janela do seu navegador que solicitará suas credenciais.
 
 Quando já estiver *logado*, você pode usar o comando `vtex whoami` para descobrir qual conta e *workspace* estão sendo usados pelo terminal.
 
-![]("https://user-images.githubusercontent.com/52087100/61886028-517e2780-aed5-11e9-9398-b6d2f3909a50.png"
+![vtex-use-nomeexemplo](https://user-images.githubusercontent.com/52087100/61886028-517e2780-aed5-11e9-9398-b6d2f3909a50.png)
   
 ## Criando seu próprio *workspace*
 
-Ao usar o VTEX IO, toda interação com uma conta acontece em um [***workspace***](*link*).
+Ao usar o `VTEX IO`, toda interação com uma conta acontece em um [***workspace***](*https://workspace.google.com/intl/pt-BR/?utm_source=google&utm_medium=cpc&utm_campaign=latam-BR-all-pt-dr-bkws-all-all-trial-e-dr-1011272-LUAC0011904&utm_content=text-ad-none-any-DEV_c-CRE_471186036169-ADGP_Hybrid+%7C+BKWS+-+EXA+%7C+Txt+~+Google+Workspace-KWID_43700057748921987-kwd-12532420&utm_term=KW_workspace-ST_workspace&--&gclid=CjwKCAjwi6WSBhA-EiwA6Niok4CQeZ4FoAkuSUqfftZbllQBcHQnOMgyovw8ozjH5v-vOazMEHOQfBoCQVEQAvD_BwE&gclsrc=aw.ds*).
 
-Ao fazer *login* em uma loja, você está automaticamente no *workspace* master dela, ou seja, na versão disponível para o usuário final. Por isso, lembre-se que sempre que você quiser testar uma nova configuração, o seu próprio *workspace* de desenvolvimento deve ser criado usando o comando `vtex use`.
+Ao fazer *login* em uma loja, você está automaticamente no *workspace master* dela, ou seja, na **versão disponível para o usuário final**. Por isso, lembre-se que sempre que você quiser testar uma nova configuração, o seu próprio *workspace* de desenvolvimento deve ser criado usando o comando `vtex use`.
 
 ```
 $ vtex use {nomeexemplo}
 ```
 
-Isso muda o seu VTEX IO CLI para um *workspace* chamado `nomeexemplo` e o cria se ele não existir.
+Isso muda o seu ***VTEX IO CLI*** para um *workspace* chamado `nomeexemplo` e o cria se ele não existir.
 
 ![vtex-use-nomeexemplo](https://user-images.githubusercontent.com/52087100/61886135-7ffc0280-aed5-11e9-983f-4a76615d0574.png)
 
->⚠️ *O `vtex use` faz com que todas as suas operações passem a ocorrer no `workspace` definido no comando. Isso significa que é possível alternar suas operações para master apenas executando no VTEX IO CLI `vtex use master`, por exemplo.*
+>⚠️ O `vtex use` faz com que todas as suas operações passem a ocorrer no `workspace` definido no comando. Isso significa que é possível alternar suas operações para *master* apenas executando no ***VTEX IO CLI*** `vtex use master`, por exemplo.
 
 Com o seu próprio *workspace* de desenvolvimento criado, você pode navegar na sua loja acessando:
 
@@ -50,4 +50,4 @@ Com o seu próprio *workspace* de desenvolvimento criado, você pode navegar na 
 
 Onde `workspace` é o *workspace* que você acabou de criar (como `nomeexemplo`) e `conta` é o nome da conta em que você está trabalhando.
 
-Pronto! Agora você já pode desenvolver sua loja no VTEX IO.
+Pronto! Agora você já pode desenvolver sua loja no `VTEX IO`.


### PR DESCRIPTION
- Adicionei uma caixa de marcação no código "vtex Io"; 
- Adicionei um Link de redirecionamento da página VTEX IO CLI;
- Adicionei ITALICO na marcação de CLI no texto e em todos atalhos subsequentes; 
- Removi o link que redirecionamento de web inexistente na palavra APPS e adicionei itálico ao termo;
- Ajustei o atalho do link, corrigindo-o na primeira imagem do doc, para tornar visível a imagem ilustrativa do visual externo;
- Onde destacava a palavra Workspace, ampliei até a palavra master;
- DESTAQUEI "versão disponível para o usuário final" em negrito por se tratar de uma info importante, afim de evidenciar que é a partir da etapa concluída que a visualização ficará visível;
- A frase inteira mencionada com o símbolo de "atenção" estava marcada em itálico, erroneamente e marcação de "master" em itálico

**What problem is this solving?**

<!--- What is the motivation and context for this change? -->

**How should this be manually tested?**

**Screenshots or example usage:**