### PR TITLE
added: CMS legacy store to the VTEX IO docs

### DIFF
--- a/docs/en/Recipes/development/creating-development-workspace-for-cms-legacy.md
+++ b/docs/en/Recipes/development/creating-development-workspace-for-cms-legacy.md
@@ -1,0 +1,33 @@
+# Creating a Development workspace in IO for a CMS legacy store
+In this guide, you will learn how to create a Development workspace to start developing in an IO environment. 
+
+When working in a Development workspace, the public version of your store, that is, the one that is visible to end users, will stay stable utilizing the CMS Legacy until you are ready to transition to IO.
+## Before you Start
+1. [Install the VTEX IO Command-line Interface (CLI)](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-vtex-io-cli-installation-and-command-reference). Through the CLI, you can log in to your VTEX account, manage workspaces and develop new apps.
+
+2. Ensure that you understand the concepts of [VTEX IO](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-what-is-vtex-io) and [workspaces](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-workspace).
+## Step-by-step
+1. Using your terminal and the [VTEX IO CLI](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-vtex-io-cli-installation-and-command-reference), log into your VTEX account by running the following command:
+
+```
+vtex login {account-name}
+```
+>  ℹ️        
+> 
+> Remember to replace the value between the brackets for the VTEX account name you desire. For example: `vtex login account-name`.
+
+2. Create a [new Development workspace](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-creating-a-development-workspace).
+
+3. [Open a ticket to the VTEX support team](https://help-tickets.vtex.com/smartlink/sso/login/zendesk?_ga=2.222513819.1487123273.1647865109-1001456323.1619912759) requesting the installation of the `vtex.edition-store@3.x` Edition app in the new Development workspace.
+
+> ℹ️ 
+> 
+> The `vtex.edition-store@3.x` Edition app is responsible for enabling building elements for the front-end using the VTEX Store Framework. You can only configure and test the solution successfully after installing it.
+
+Once the `vtex.edition-store@3.x` Edition app is installed in the Development workspace, configure the Store Framework theme you want in the Store Theme app and test it in the new Development workspace. Refer to the [Setting your store's theme](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-3-settingyourstoretheme) documentation for more details.
+
+## Next steps
+1. Make sure to configure the Store theme for the Development workspace you have created. Refer to the [Setting your store's theme](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-3-settingyourstoretheme) documentation for more details.
+
+
+2. After finishing setting your Store Theme, perform A/B testing between the Development workspace in IO and the Master workspace in the CMS legacy. Refer to the [Performing A/B testing between store versions in CMS and VTEX IO]() documentation.

--- a/docs/en/Recipes/development/creating-development-workspace-for-cms-legacy.md
+++ b/docs/en/Recipes/development/creating-development-workspace-for-cms-legacy.md
@@ -30,4 +30,4 @@ Once the `vtex.edition-store@3.x` Edition app is installed in the Development wo
 1. Make sure to configure the Store theme for the Development workspace you have created. Refer to the [Setting your store's theme](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-3-settingyourstoretheme) documentation for more details.
 
 
-2. After finishing setting your Store Theme, perform A/B testing between the Development workspace in IO and the Master workspace in the CMS legacy. Refer to the [Performing A/B testing between store versions in CMS and VTEX IO]() documentation.
+2. After finishing setting your Store Theme, perform A/B testing between the Development workspace in IO and the Master workspace in the CMS legacy. Refer to the [Performing A/B testing between store versions in CMS and VTEX IO](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-performing-ab-testing-between-store-versions-in-cms-and-vtex-io) guide.

--- a/docs/en/Recipes/development/performing-ab-testing-between-legacy-and-io.md
+++ b/docs/en/Recipes/development/performing-ab-testing-between-legacy-and-io.md
@@ -1,0 +1,74 @@
+# Performing A/B testing between store versions in CMS and VTEX IO 
+In this guide, you will learn how to perform A/B testing between store workspaces in CMS Legacy and VTEX IO to confirm which workspace has the highest conversion rate for your store.
+
+## Before you start
+1. [Install the VTEX IO Command-line Interface (CLI)](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-vtex-io-cli-installation-and-command-reference). Through the CLI, you can log in to your VTEX account, manage workspaces and develop new apps.
+
+2. Ensure that you already have a Development workspace for your account. Otherwise, create and set up one following [Creating a Development workspace in IO for a CMS legacy store]() guide.
+
+3. Ensure that your Development workspace has the `vtex.edition-store@3.x` Edition app installed. Run the `vtex edition get` in your terminal to verify the Edition App version installed on the current account. Otherwise, [Open a ticket to the VTEX support team](https://help-tickets.vtex.com/smartlink/sso/login/zendesk?_ga=2.222513819.1487123273.1647865109-1001456323.1619912759) requesting the installation of the `vtex.edition-store@3.x` Edition app in the new Development workspace.
+
+
+## Step-by-step 
+
+1. Using your terminal and the [VTEX IO CLI](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-vtex-io-cli-installation-and-command-reference), log into your VTEX account by running the following command:
+
+```
+vtex login {account-name}
+```
+>  ℹ️        
+> 
+> Remember to replace the value between the brackets for the VTEX account name you desire. For example: `vtex login account-name`.
+
+
+5. Access the Development workspace that you have created by running:
+```
+vtex use {workspace} 
+```
+>  ℹ️        
+> 
+> Remember to replace the value between the brackets for the Development workspace you desire. For example: `vtex login test`.
+
+6. Run the `vtex use Master` command in your terminal to perform the steps below in the Master workspace. The Master workspace must be set to the `vtex.edition-business@0.x` [edition app](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-edition-app).
+
+7. Install the `vtex.colossus-legacy-proxy@@1.8.9-hkignore` app. This is an essential step to avoid that you store in production break. 
+
+>⚠️ 
+> 
+> The app’s version must be `vtex.colossus-legacy-proxy@@1.8.9-hkignore`. If not, the store won’t respond to the request.
+
+8. [Open a ticket to the VTEX support team](https://help-tickets.vtex.com/smartlink/sso/login/zendesk?_ga=2.222513819.1487123273.1647865109-1001456323.1619912759) requesting the redirection of the production workspace to be rendered in VTEX IO
+
+>⚠️ 
+> 
+> If the store has a different storefront for mobile, inform this in the ticket to the VTEX support.
+
+9. Once the Production workspace is rendering in the VTEX IO, you can enable the A/B test between the workspaces described in the [Running native A/B tests](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-running-native-ab-testing) step-by-step.
+
+### Validating if the A/B test is running
+
+1. To ensure that the A/B test is working, make a GET response in the following API:
+
+`http://platform.io.vtex.com/{{account}}/_abtest/parameters`
+
+> ⚠️
+>
+> The Header must have `VtexIdclientAutCookie` from the account you want to get the information. For example: `VtexIdclientAutCookie: {{VtexIdclientAutCookie}}`
+
+2. The result should be similar to the following:
+
+```
+"master": {
+            "A": 9000,
+            "b": 1
+        },
+        "wsio": {
+            "A": 1000,
+            "b": 1
+        }
+
+```
+The result means that the `master` is with 90% of the traffic and the `wsio` is with 10%.
+
+## Next Step    
+After finishing the A/B test and want to migrate your store to IO, [open a ticket to the VTEX support team](https://help-tickets.vtex.com/smartlink/sso/login/zendesk?_ga=2.222513819.1487123273.1647865109-1001456323.1619912759)  requesting the migration of your Development workspace to the IO.

--- a/docs/en/Recipes/development/performing-ab-testing-between-legacy-and-io.md
+++ b/docs/en/Recipes/development/performing-ab-testing-between-legacy-and-io.md
@@ -4,7 +4,7 @@ In this guide, you will learn how to perform A/B testing between store workspace
 ## Before you start
 1. [Install the VTEX IO Command-line Interface (CLI)](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-vtex-io-cli-installation-and-command-reference). Through the CLI, you can log in to your VTEX account, manage workspaces and develop new apps.
 
-2. Ensure that you already have a Development workspace for your account. Otherwise, create and set up one following [Creating a Development workspace in IO for a CMS legacy store]() guide.
+2. Ensure that you already have a Development workspace for your account. Otherwise, create and set up one following [Creating a Development workspace in IO for a CMS legacy store](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-creating-a-development-workspace-in-io-for-a -cms-legacy-store) guide.
 
 3. Ensure that your Development workspace has the `vtex.edition-store@3.x` Edition app installed. Run the `vtex edition get` in your terminal to verify the Edition App version installed on the current account. Otherwise, [Open a ticket to the VTEX support team](https://help-tickets.vtex.com/smartlink/sso/login/zendesk?_ga=2.222513819.1487123273.1647865109-1001456323.1619912759) requesting the installation of the `vtex.edition-store@3.x` Edition app in the new Development workspace.
 


### PR DESCRIPTION
**What problem is this solving?**

Added:

- Migrating a CMS legacy store to the VTEX IO doc
-  Performing A/B testing between store versions in CMS and VTEX IO doc