### PR TITLE
fix: links for migrating to IO docs

### DIFF
--- a/docs/en/Recipes/development/creating-development-workspace-for-cms-legacy.md
+++ b/docs/en/Recipes/development/creating-development-workspace-for-cms-legacy.md
@@ -1,4 +1,4 @@
-# Creating a Development workspace in IO for a CMS legacy store
+# Creating a Development workspace for a CMS legacy store
 In this guide, you will learn how to create a Development workspace to start developing in an IO environment. 
 
 When working in a Development workspace, the public version of your store, that is, the one that is visible to end users, will stay stable utilizing the CMS Legacy until you are ready to transition to IO.
@@ -30,4 +30,4 @@ Once the `vtex.edition-store@3.x` Edition app is installed in the Development wo
 1. Make sure to configure the Store theme for the Development workspace you have created. Refer to the [Setting your store's theme](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-3-settingyourstoretheme) documentation for more details.
 
 
-2. After finishing setting your Store Theme, perform A/B testing between the Development workspace in IO and the Master workspace in the CMS legacy. Refer to the [Performing A/B testing between store versions in CMS and VTEX IO](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-performing-ab-testing-between-store-versions-in-cms-and-vtex-io) guide.
+2. After finishing setting your Store Theme, perform A/B testing between the Development workspace in IO and the Master workspace in the CMS legacy. Refer to the [Performing A/B testing between store versions in CMS and VTEX IO](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-performing-ab-testing-between-legacy-and-io) guide.

--- a/docs/en/Recipes/development/performing-ab-testing-between-legacy-and-io.md
+++ b/docs/en/Recipes/development/performing-ab-testing-between-legacy-and-io.md
@@ -1,10 +1,10 @@
-# Performing A/B testing between store versions in CMS and VTEX IO 
+# Performing A/B testing between store versions
 In this guide, you will learn how to perform A/B testing between store workspaces in CMS Legacy and VTEX IO to confirm which workspace has the highest conversion rate for your store.
 
 ## Before you start
 1. [Install the VTEX IO Command-line Interface (CLI)](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-vtex-io-cli-installation-and-command-reference). Through the CLI, you can log in to your VTEX account, manage workspaces and develop new apps.
 
-2. Ensure that you already have a Development workspace for your account. Otherwise, create and set up one following [Creating a Development workspace in IO for a CMS legacy store](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-creating-a-development-workspace-in-io-for-a -cms-legacy-store) guide.
+2. Ensure that you already have a Development workspace for your account. Otherwise, create and set up one following [Creating a Development workspace in IO for a CMS legacy store](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-creating-development-workspace-for-cms-legacy) guide.
 
 3. Ensure that your Development workspace has the `vtex.edition-store@3.x` Edition app installed. Run the `vtex edition get` in your terminal to verify the Edition App version installed on the current account. Otherwise, [Open a ticket to the VTEX support team](https://help-tickets.vtex.com/smartlink/sso/login/zendesk?_ga=2.222513819.1487123273.1647865109-1001456323.1619912759) requesting the installation of the `vtex.edition-store@3.x` Edition app in the new Development workspace.
 


### PR DESCRIPTION
**What problem is this solving?**

Fixed
- URL path to other docs