### PR TITLE
Add missing step on "setting up google tag manager" doc 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Additional steps on how to configure Google Tag Manager, more specifically, how to configure the "page" field on Google Analytics Settings variables.
 
 ## [0.87.69] - 2022-06-21
 

--- a/docs/en/Recipes/store-management/setting-up-google-tag-manager.md
+++ b/docs/en/Recipes/store-management/setting-up-google-tag-manager.md
@@ -123,10 +123,10 @@ You will create one variable for the storefront - default - and another for the 
 1. In the **User-Defined Variables** box, click on `New`.
 2. Click on the **Variable Configuration** box and select **Google Analytics Settings**.
 3. Type in your [**Google Analytics Tracking ID**](https://support.google.com/tagmanager/answer/9207621#ga_id), `{{Analytics Tracking ID}}`.
-4. Click on **More Settings**, **Fields to Set** and click on `Add Field`.
-5. In **Field**, type `location` and in **Value** `{{Original Location}}`.
-6. Click again on `Add Field` and In **Field**, type `referrer` and in **Value** `{{Original Referrer}}`.
-7. Click again on `Add Field` and In **Field**, type `page` and in **Value** `{{Page Path}}`.
+4. Go to **More Settings > Fields to Set**.
+5. Click the **Add Field** button. Then, type `location` in **Field Name** and `{{Original Location}}` in the **Value** field.
+6. Click **Add Field**. Then, type `referrer` in **Field Name** and `{{Original Referrer}}` in the **Value** field.
+7. Click **Add Field**. Then, type `page` in **Field Name** and `{{Page Path}}` in the **Value** field.
 
 ![img-example](https://user-images.githubusercontent.com/67270558/149200665-162c9354-ccba-4b20-bbcd-ec2339f10ba8.png)
 
@@ -141,12 +141,12 @@ To do this, click on Fields to set and add the `userId` field with its desired v
 1. In the **User-Defined Variables** box, click on `New`.
 2. Click on the **Variable Configuration** box and select **Google Analytics Settings**.
 3. Type in your **Google Analytics Tracking ID**, `{{Analytics Tracking ID}}`.
-4. Click on **More Settings**, **Fields to Set** and click on `Add Field`.
-5. In **Field**, type `location` and in **Value** `{{Original Location}}`.
-6. Click again on `Add Field` and In **Field**, type `referrer` and in **Value** `{{Original Referrer}}`.
-7. Click again on `Add Field` and In **Field**, type `page` and in **Value** `{{Page Path}}`.
-8. Then, go to **Ecommerce**  and tick the `Enable Enhanced Ecommerce Features`.
-9. In `Read data from variable` select `{{ecommerceV2}}`.
+4. Go to **More Settings > Fields to Set**.
+5. Click the **Add Field** button. Then, type `location` in **Field Name** and `{{Original Location}}` in the **Value** field.
+6. Click the **Add Field** button. Then, type `referrer` in **Field Name** and `{{Original Referrer}}` in the **Value** field.
+7. Click the **Add Field** button. Then, type `page` in **Field Name** and `{{Page Path}}` in the **Value** field.
+8. Then, go to the **Ecommerce** section and tick the `Enable Enhanced Ecommerce Features` option.
+9. Select the `{{ecommerceV2}}` option in **Read data from variable**.
 10. Save your changes as **Google Analytics - Checkout and Order Placed**.
 
 > ⚠️ Warning

--- a/docs/en/Recipes/store-management/setting-up-google-tag-manager.md
+++ b/docs/en/Recipes/store-management/setting-up-google-tag-manager.md
@@ -126,6 +126,7 @@ You will create one variable for the storefront - default - and another for the 
 4. Click on **More Settings**, **Fields to Set** and click on `Add Field`.
 5. In **Field**, type `location` and in **Value** `{{Original Location}}`.
 6. Click again on `Add Field` and In **Field**, type `referrer` and in **Value** `{{Original Referrer}}`.
+7. Click again on `Add Field` and In **Field**, type `page` and in **Value** `{{Page Path}}`.
 
 ![img-example](https://user-images.githubusercontent.com/67270558/149200665-162c9354-ccba-4b20-bbcd-ec2339f10ba8.png)
 
@@ -143,9 +144,10 @@ To do this, click on Fields to set and add the `userId` field with its desired v
 4. Click on **More Settings**, **Fields to Set** and click on `Add Field`.
 5. In **Field**, type `location` and in **Value** `{{Original Location}}`.
 6. Click again on `Add Field` and In **Field**, type `referrer` and in **Value** `{{Original Referrer}}`.
-7. Then, go to **Ecommerce**  and tick the `Enable Enhanced Ecommerce Features`.
-8. In `Read data from variable` select `{{ecommerceV2}}`.
-9. Save your changes as **Google Analytics - Checkout and Order Placed**.
+7. Click again on `Add Field` and In **Field**, type `page` and in **Value** `{{Page Path}}`.
+8. Then, go to **Ecommerce**  and tick the `Enable Enhanced Ecommerce Features`.
+9. In `Read data from variable` select `{{ecommerceV2}}`.
+10. Save your changes as **Google Analytics - Checkout and Order Placed**.
 
 > ⚠️ Warning
 >


### PR DESCRIPTION
**What problem is this solving?**

Add missing step on "setting up google tag manager" doc regarding the page field. Without this, reports on Google Analytics may look as if they are coming from a single path, when that's really not the case.

**How should this be manually tested?**

**Screenshots or example usage:**